### PR TITLE
Fix integer bounds for large inputs and add tests

### DIFF
--- a/frontends/concrete-python/concrete/fhe/dtypes/integer.py
+++ b/frontends/concrete-python/concrete/fhe/dtypes/integer.py
@@ -11,6 +11,30 @@ import numpy as np
 from .base import BaseDataType
 
 
+def _integer_bounds_from_object_array(array: np.ndarray) -> tuple[int, int]:
+    """Extract minimum and maximum integer values from an object numpy array."""
+
+    integers: list[int] = []
+
+    for element in array.flat:
+        if isinstance(element, (bool, np.bool_)):
+            integers.append(int(element))
+            continue
+
+        if isinstance(element, (int, np.integer)):
+            integers.append(int(element))
+            continue
+
+        message = f"Integer cannot represent {repr(array)}"
+        raise ValueError(message)
+
+    if not integers:
+        message = f"Integer cannot represent {repr(array)}"
+        raise ValueError(message)
+
+    return min(integers), max(integers)
+
+
 class Integer(BaseDataType):
     """
     Integer class, to represent integers.
@@ -64,18 +88,28 @@ class Integer(BaseDataType):
 
         if isinstance(value, list):
             try:
-                value = np.array(value, dtype=np.int64)
+                value = np.array(value)
             except Exception:  # pylint: disable=broad-except
                 # here we try our best to convert the list to np.ndarray
                 # if it fails we raise the exception at the else branch below
                 pass
 
-        if isinstance(value, (int, np.integer)):
+        if isinstance(value, (bool, np.bool_, int, np.integer)):
             lower_bound = int(value)
             upper_bound = int(value)
-        elif isinstance(value, np.ndarray) and np.issubdtype(value.dtype, np.integer):
-            lower_bound = int(value.min())
-            upper_bound = int(value.max())
+        elif isinstance(value, np.ndarray):
+            if value.size == 0:
+                message = f"Integer cannot represent {repr(value)}"
+                raise ValueError(message)
+
+            if np.issubdtype(value.dtype, np.integer) or np.issubdtype(value.dtype, np.bool_):
+                lower_bound = int(value.min())
+                upper_bound = int(value.max())
+            elif value.dtype == object:
+                lower_bound, upper_bound = _integer_bounds_from_object_array(value)
+            else:
+                message = f"Integer cannot represent {repr(value)}"
+                raise ValueError(message)
         else:
             message = f"Integer cannot represent {repr(value)}"
             raise ValueError(message)
@@ -172,3 +206,4 @@ class Integer(BaseDataType):
 SignedInteger = partial(Integer, True)
 
 UnsignedInteger = partial(Integer, False)
+

--- a/frontends/concrete-python/concrete/fhe/values/value_description.py
+++ b/frontends/concrete-python/concrete/fhe/values/value_description.py
@@ -74,12 +74,17 @@ class ValueDescription:
                     dtype=UnsignedInteger(1), shape=value.shape, is_encrypted=is_encrypted
                 )
 
-            if np.issubdtype(value.dtype, np.integer):
-                return ValueDescription(
-                    dtype=Integer.that_can_represent(value),
-                    shape=value.shape,
-                    is_encrypted=is_encrypted,
-                )
+            if np.issubdtype(value.dtype, np.integer) or value.dtype == object:
+                try:
+                    integer_dtype = Integer.that_can_represent(value)
+                except ValueError:
+                    pass
+                else:
+                    return ValueDescription(
+                        dtype=integer_dtype,
+                        shape=value.shape,
+                        is_encrypted=is_encrypted,
+                    )
 
             if np.issubdtype(value.dtype, np.float64):
                 return ValueDescription(
@@ -171,3 +176,4 @@ class ValueDescription:
         """
 
         return int(np.prod(self.shape))
+

--- a/frontends/concrete-python/tests/dtypes/test_integer.py
+++ b/frontends/concrete-python/tests/dtypes/test_integer.py
@@ -121,6 +121,31 @@ from concrete.fhe.dtypes import Integer, SignedInteger, UnsignedInteger
             True,
             SignedInteger(2),
         ),
+        pytest.param(
+            [2**63],
+            False,
+            UnsignedInteger(64),
+        ),
+        pytest.param(
+            [2**63],
+            True,
+            SignedInteger(65),
+        ),
+        pytest.param(
+            np.array([2**63], dtype=object),
+            False,
+            UnsignedInteger(64),
+        ),
+        pytest.param(
+            np.array([2**63], dtype=object),
+            True,
+            SignedInteger(65),
+        ),
+        pytest.param(
+            [2**100],
+            False,
+            UnsignedInteger(101),
+        ),
     ],
 )
 def test_integer_that_can_represent(value, force_signed, expected_result):
@@ -689,3 +714,4 @@ def test_integer_can_represent(data_type, value, expected_result):
     """
 
     assert data_type.can_represent(value) == expected_result
+

--- a/frontends/concrete-python/tests/values/test_value.py
+++ b/frontends/concrete-python/tests/values/test_value.py
@@ -89,6 +89,36 @@ from concrete.fhe.values import (
             ValueDescription(dtype=UnsignedInteger(2), shape=(4,), is_encrypted=True),
         ),
         pytest.param(
+            [2**63],
+            False,
+            ValueDescription(dtype=UnsignedInteger(64), shape=(1,), is_encrypted=False),
+        ),
+        pytest.param(
+            [2**63],
+            True,
+            ValueDescription(dtype=UnsignedInteger(64), shape=(1,), is_encrypted=True),
+        ),
+        pytest.param(
+            np.array([2**63], dtype=object),
+            False,
+            ValueDescription(dtype=UnsignedInteger(64), shape=(1,), is_encrypted=False),
+        ),
+        pytest.param(
+            np.array([2**63], dtype=object),
+            True,
+            ValueDescription(dtype=UnsignedInteger(64), shape=(1,), is_encrypted=True),
+        ),
+        pytest.param(
+            [2**100],
+            False,
+            ValueDescription(dtype=UnsignedInteger(101), shape=(1,), is_encrypted=False),
+        ),
+        pytest.param(
+            [2**100],
+            True,
+            ValueDescription(dtype=UnsignedInteger(101), shape=(1,), is_encrypted=True),
+        ),
+        pytest.param(
             np.array([0.2, 3.4, 1.5, 2.0], dtype=np.float64),
             False,
             ValueDescription(dtype=Float(64), shape=(4,), is_encrypted=False),
@@ -325,3 +355,4 @@ def test_value_size(value, expected_result):
     """
 
     assert value.size == expected_result
+


### PR DESCRIPTION
## Summary
- handle large integer lists and object arrays in Integer.that_can_represent without overflow
- update ValueDescription.of to reuse the new helper when numpy arrays hold big ints
- add regression tests covering 2**63 and 2**100 scenarios for integers and value descriptions

## Testing
- not run (Python missing on contributor machine)